### PR TITLE
Fix:[#1] serverOption for logger cause type error

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -20,7 +20,7 @@ export const bootstrapServer = async (): Promise<NestApp> => {
   const instance: FastifyInstance = fastify(serverOptions);
   const app = await NestFactory.create<NestFastifyApplication>(
     AppModule,
-    new FastifyAdapter(instance),
+    new FastifyAdapter({ logger: true }),
   );
 
   await app.init();


### PR DESCRIPTION
기존 코드를 `yarn start:dev`로 실행시
<img width="1322" alt="스크린샷 2025-03-27 오후 5 38 58" src="https://github.com/user-attachments/assets/72a77fdd-7f3c-4366-8c7d-9f831ac029d7" />
다음과 같은 오류 발생하여

오류가 나는 부분을 [fastify 공식문서 로깅파트](https://fastify.dev/docs/latest/Reference/Logging/#enable-logging) 보고 { logging: true }로 수정했더니
<img width="1146" alt="스크린샷 2025-03-27 오후 5 38 11" src="https://github.com/user-attachments/assets/00fbdadf-44d7-49b2-911f-e51eff69e5e9" />
무사히 실행됩니다.